### PR TITLE
Fix injector:unpr when minfied

### DIFF
--- a/ng-text-truncate.js
+++ b/ng-text-truncate.js
@@ -16,13 +16,13 @@
                 customMoreLabel: "@ngTtMoreLabel",
                 customLessLabel: "@ngTtLessLabel"
             },
-            controller: function( $scope, $element, $attrs ) {
+            controller: ['$scope','$element','$attrs',function( $scope, $element, $attrs ) {
                 $scope.toggleShow = function() {
                     $scope.open = !$scope.open;
                 };
 
                 $scope.useToggling = $attrs.ngTtNoToggling === undefined;
-            },
+            }],
             link: function( $scope, $element, $attrs ) {
                 $scope.open = false;
 


### PR DESCRIPTION
When ng-text-truncate.js is minified, it will throw an error reference exception of unknown provider. This changes was to fix the issue
